### PR TITLE
Update Getting Started instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 Final state of Tutorial code running on latest release version. This is where the testing happens.
 
 ### Deployed on Netlify
-TODO
+https://redwoodjs-tutorial-test.netlify.app
 
 ### Deployed on Vercel
 https://redwood-tutorial-test.vercel.app/
+
+### Deployed on Render
+- Postgres: https://tdp-redwood-tutorial-test-web-r3h6.onrender.com
+- SQLite: https://tdp-redwood-tutorial-test-web.onrender.com
 
 ## Getting Started
 - [Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood): getting started and complete overview guide.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 # Redwood Tutorial Testing Repo
-Final state of Tutorial code running on latest release version.
-
-This is where the testing happens.
+Final state of Tutorial code running on latest release version. This is where the testing happens.
 
 ### Deployed on Netlify
-https://jovial-bohr-4ac134.netlify.com/
-
-### Deployed on Vercel
 TODO
 
+### Deployed on Vercel
+https://redwood-tutorial-test.vercel.app/
 
 ## Getting Started
-- [Redwoodjs.com](https://redwoodjs.com): home to all things RedwoodJS.
 - [Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood): getting started and complete overview guide.
 - [Docs](https://redwoodjs.com/docs/introduction): using the Redwood Router, handling assets and files, list of command-line tools, and more.
 - [Redwood Community](https://community.redwoodjs.com): get help, share tips and tricks, and collaborate on everything about RedwoodJS.
@@ -27,10 +23,10 @@ yarn install
 ### Fire it up
 
 ```terminal
-yarn redwood dev
+yarn rw dev
 ```
 
-Your browser should open automatically to `http://localhost:8910` to see the web app. Lambda functions run on `http://localhost:8911` and are also proxied to `http://localhost:8910/api/functions/*`.
+Your browser should open automatically to `http://localhost:8910` to see the web app. Lambda functions run on `http://localhost:8911` and are also proxied to `http://localhost:8910/.netlify/functions/*`.
 
 ## Development
 
@@ -38,14 +34,14 @@ Your browser should open automatically to `http://localhost:8910` to see the web
 
 We're using [Prisma2](https://github.com/prisma/prisma2), a modern DB toolkit to query, migrate and model your database.
 
-Prisma2 is [not ready for production](https://isprisma2ready.com) at the moment.
+To create a development database, you will need to create a `.env` file and include a PostgreSQL environment variable like the `DATABASE_URL` specified in `.env.defaults`, see either:
+* [This link](https://community.redwoodjs.com/t/setup-database-with-railway-cli/2025) for instructions on quickly setting up a database on Railway.
+* [This link](https://redwoodjs.com/docs/local-postgres-setup.html) for setting up PostgreSQL locally.
 
-To create a development database:
+After doing that, run the following command:
 
 ```terminal
-yarn redwood db up
+yarn rw prisma migrate dev
 ```
 
-This will read the schema definition in `api/prisma/schema.prisma` and generate a sqlite database in `api/prisma/dev.db`
-
-If you've made changes to the schema run `yarn redwood db save` to generate a migration, and `yarn redwood db up` to apply the migration/ generate a new ORM client.
+This will read the schema definition in `api/db/schema.prisma`.


### PR DESCRIPTION
Noticed quite a bit of drift between the current README and actual state of the repo, this PR addresses a handful of different fixes:

* Netlify link is dead, changed it to TODO and included the currently working Vercel link.
* With the current `redwood.toml` configuration, Lambda functions are being proxied to `8910/.netlify/functions/*` and not `8910/api/functions/*`
* Removed old Prisma commands and included new `prisma migrate dev` command.
* The README still assumes the project is setup for SQLite but the migrations and `prisma.schema` are setup for Postgres.
  * I've included instructions for getting a Postgres db running locally or on a hosting provider.
  * If we wanted we could also include instructions for deleting the migrations, changing the `prisma.schema` to `sqlite`, and then rerunning the migrations.